### PR TITLE
gpxsee: update to 13.7

### DIFF
--- a/package.yml
+++ b/package.yml
@@ -1,8 +1,8 @@
 name       : gpxsee
-version    : '13.6'
-release    : 24
+version    : '13.7'
+release    : 25
 source     :
-    - https://github.com/tumic0/GPXSee/archive/refs/tags/13.6.tar.gz : ef76dcc39b7419dda70c7096f049c4f954134fc4273a7d45b93203f68d2a066f
+    - https://github.com/tumic0/GPXSee/archive/refs/tags/13.7.tar.gz : 6735a62693080b8a311e04e17192c9ee565be4d184e0617cc881308149e76bd5
 homepage   : https://www.gpxsee.org
 license    : GPL-3.0-or-later
 component  : desktop

--- a/pspec_x86_64.xml
+++ b/pspec_x86_64.xml
@@ -130,9 +130,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="24">
-            <Date>2023-08-16</Date>
-            <Version>13.6</Version>
+        <Update release="25">
+            <Date>2023-08-31</Date>
+            <Version>13.7</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
### Summary
- Fixed/improved map info background rendering settings
- Improved Mapsforge and ENC maps rendering
- Switched to Android SDK 33
- Added missing Windows quiet uninstaller entry

### Test Plan
open Garmin map; zoom in and out;

### Checklist
- [X] Package was built and tested against unstable
