### PR TITLE
gpxsee: update to 13.8

### DIFF
--- a/abi_used_symbols
+++ b/abi_used_symbols
@@ -158,6 +158,7 @@ libQt5Core.so.5:_ZN4QUrl13fromLocalFileERK7QString
 libQt5Core.so.5:_ZN4QUrlC1ERK7QStringNS_11ParsingModeE
 libQt5Core.so.5:_ZN4QUrlC1ERKS_
 libQt5Core.so.5:_ZN4QUrlD1Ev
+libQt5Core.so.5:_ZN5QChar10digitValueEj
 libQt5Core.so.5:_ZN5QChar14isSpace_helperEj
 libQt5Core.so.5:_ZN5QChar15isLetter_helperEj
 libQt5Core.so.5:_ZN5QChar7toLowerEj
@@ -340,6 +341,7 @@ libQt5Core.so.5:_ZNK10QByteArray6toUIntEPbi
 libQt5Core.so.5:_ZNK10QByteArray7indexOfEPKci
 libQt5Core.so.5:_ZNK10QByteArray7indexOfEci
 libQt5Core.so.5:_ZNK10QByteArray7toFloatEPb
+libQt5Core.so.5:_ZNK10QByteArray8endsWithEPKc
 libQt5Core.so.5:_ZNK10QByteArray8toBase64Ev
 libQt5Core.so.5:_ZNK10QByteArray8toDoubleEPb
 libQt5Core.so.5:_ZNK10QJsonArray2atEi
@@ -365,6 +367,7 @@ libQt5Core.so.5:_ZNK11QMetaObject2trEPKcS1_i
 libQt5Core.so.5:_ZNK11QMetaObject4castEP7QObject
 libQt5Core.so.5:_ZNK11QMetaObject9classNameEv
 libQt5Core.so.5:_ZNK11QObjectData17dynamicMetaObjectEv
+libQt5Core.so.5:_ZNK12QMapNodeBase12previousNodeEv
 libQt5Core.so.5:_ZNK12QMapNodeBase8nextNodeEv
 libQt5Core.so.5:_ZNK13QJsonDocument6isNullEv
 libQt5Core.so.5:_ZNK13QJsonDocument6objectEv
@@ -767,6 +770,7 @@ libQt5Gui.so.5:_ZNK5QFont9pixelSizeEv
 libQt5Gui.so.5:_ZNK5QFont9pointSizeEv
 libQt5Gui.so.5:_ZNK5QIcon10actualSizeERK5QSizeNS_4ModeENS_5StateE
 libQt5Gui.so.5:_ZNK5QIcon6pixmapERK5QSizeNS_4ModeENS_5StateE
+libQt5Gui.so.5:_ZNK6QBrusheqERKS_
 libQt5Gui.so.5:_ZNK6QColor3rgbEv
 libQt5Gui.so.5:_ZNK6QColor4nameEv
 libQt5Gui.so.5:_ZNK6QColor5toRgbEv

--- a/package.yml
+++ b/package.yml
@@ -1,8 +1,8 @@
 name       : gpxsee
-version    : '13.7'
-release    : 25
+version    : '13.8'
+release    : 26
 source     :
-    - https://github.com/tumic0/GPXSee/archive/refs/tags/13.7.tar.gz : 6735a62693080b8a311e04e17192c9ee565be4d184e0617cc881308149e76bd5
+    - https://github.com/tumic0/GPXSee/archive/refs/tags/13.8.tar.gz : cdfeeb500405a86f2e32e7ba0eb5b3063f96329889239f65513474a5dbd3d283
 homepage   : https://www.gpxsee.org
 license    : GPL-3.0-or-later
 component  : desktop

--- a/pspec_x86_64.xml
+++ b/pspec_x86_64.xml
@@ -130,9 +130,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="25">
-            <Date>2023-08-31</Date>
-            <Version>13.7</Version>
+        <Update release="26">
+            <Date>2023-09-14</Date>
+            <Version>13.8</Version>
             <Comment>Packaging update</Comment>
             <Name>Nazar Stasiv</Name>
             <Email>nazar@autistici.org</Email>


### PR DESCRIPTION
### Summary
- Added support for ENC atlases (catalogues).
- Fixed broken "Use styles" persistent configuration.

### Test Plan
open garmin map; zoom in and out

### Checklist
- [X] Package was built and tested against unstable
